### PR TITLE
Allow use of variable to set nonce

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,7 @@ task :setup_nginx do
   make_content_dir 'download'
   make_content_dir 'allow_token1'
   make_content_dir 'allow_all'
+  make_content_dir 'using_vars'
 end
 
 def make_content_dir(dir)

--- a/setup-files/nginx.conf.patch
+++ b/setup-files/nginx.conf.patch
@@ -1,5 +1,5 @@
---- nginx-1.0.5/prefix/conf/nginx.conf.default	2011-10-30 23:29:45.000000000 +0000
-+++ nginx-1.0.5/prefix/conf/nginx.conf	2011-10-30 23:29:23.000000000 +0000
+--- nginx-1.6.1/prefix/conf/nginx.conf.default	2019-03-28 17:43:10.000000000 -0300
++++ nginx-1.6.1/prefix/conf/nginx.conf	2019-03-28 17:47:57.000000000 -0300
 @@ -1,3 +1,4 @@
 +daemon off;
  
@@ -22,7 +22,7 @@
          server_name  localhost;
  
          #charset koi8-r;
-@@ -43,6 +45,24 @@
+@@ -43,6 +45,33 @@
          location / {
              root   html;
              index  index.html index.htm;
@@ -43,6 +43,15 @@
 +                g2o        off;
 +                g2o_nonce  "token";
 +                g2o_key    "a_password";
++            }
++
++            location /using_vars {
++                set $token "token";
++                set $pass  "a_password";
++
++                g2o        on;
++                g2o_nonce  $token;
++                g2o_key    $pass;
 +            }
          }
  

--- a/spec/nginx_g2o_spec.rb
+++ b/spec/nginx_g2o_spec.rb
@@ -131,6 +131,33 @@ describe 'nginx mod' do
       end
     end
 
+    context "using variables to set token and password into the conf" do
+      before do
+        @uri = URI.parse('http://localhost:8080/using_vars/stuff.html')
+      end
+
+      it 'should allow access to content with correct G2O headers' do
+        data = g2o_data_header
+        sign = sign_data(data)
+
+        get(data, sign).should respond_with(Net::HTTPOK)
+      end
+
+      it 'should disallow access to content if using wrong token' do
+        data = g2o_data_header(:token => "wrong_token")
+        sign = sign_data(data)
+
+        get(data, sign).should respond_with(Net::HTTPForbidden)
+      end
+
+      it 'should disallow access to content if using wrong password' do
+        data = g2o_data_header
+        sign = sign_data(data, :key => "wrong_password")
+
+        get(data, sign).should respond_with(Net::HTTPForbidden)
+      end
+    end
+
     it 'should disallow access to content without G2O headers' do
       get.should respond_with(Net::HTTPForbidden)
     end


### PR DESCRIPTION
It will make it possible to use vars to set the nonce value. Like this:

```
location /download {
    g2o        on;
    g2o_nonce  $token; # consider that var has already been set
    g2o_key    "a_password";
}
```